### PR TITLE
Fix header formatting so package.el can parse the description

### DIFF
--- a/tramp-hlo.el
+++ b/tramp-hlo.el
@@ -22,7 +22,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
 
-;;; Commentary
+;;; Commentary:
 
 ;; This is an attempt to optimize Tramp remote editing with slow
 ;; connection by building higher level core lisp functions as Tramp


### PR DESCRIPTION
This missing colon is the reason why the package description is empty in the Emacs package list details view.