### PR TITLE
Refactor/bugfix parents and dominating-file scripts

### DIFF
--- a/tramp-hlo.el
+++ b/tramp-hlo.el
@@ -61,6 +61,7 @@ characters need to be doubled.")
 
 (defconst tramp-hlo-list-parents-script "\
 TEST=\"${1%%/}\"
+[ -z \"$TEST\" ] && echo \"()\" && return
 if [ ! -d $(%r -f \"$TEST\") ]; then
     TEST=\"$(dirname \"$TEST\")\"
 fi
@@ -79,25 +80,26 @@ Format specifiers are replaced by `tramp-expand-script', percent
 characters need to be doubled.")
 
 (defconst tramp-hlo-locate-dominating-file-multi-script "\
-    TEST=\"${1%%/}\"
-    if [ ! -d $(%r -f \"$TEST\") ]; then
-	TEST=\"$(dirname \"$TEST\")\"
+TEST=\"${1%%/}\"
+[ -z \"$TEST\" ] && echo \"()\" && return
+if [ ! -d $(%r -f \"$TEST\") ]; then
+    TEST=\"$(dirname \"$TEST\")\"
+fi
+shift
+echo \\(
+FOUND=\"\"
+while
+    if [ -d \"$TEST\" ]; then
+        for NAME in \"$@\"; do
+    	if [ -e \"$TEST/$NAME\" ]; then
+                %k \"$TEST/$NAME\"
+                FOUND=1
+    	fi
+        done
     fi
-    shift
-    echo \\(
-    FOUND=\"\"
-    while
-	if [ -d \"$TEST\" ]; then
-            for NAME in \"$@\"; do
-		if [ -e \"$TEST/$NAME\" ]; then
-                    %k \"$TEST/$NAME\"
-                    FOUND=1
-		fi
-            done
-	fi
-        [ -z \"$FOUND\" ] && [ \"$TEST\" != \"/\" ]
-    do TEST=$(dirname \"$TEST\"); done
-    echo \\)
+    [ -z \"$FOUND\" ] && [ \"$TEST\" != \"/\" ]
+do TEST=$(dirname \"$TEST\"); done
+echo \\)
 "
   "Script to find several dominating files on a remote host.
 Arguments are like in `locate-dominating-file', but with supporting

--- a/tramp-hlo.el
+++ b/tramp-hlo.el
@@ -62,14 +62,12 @@ characters need to be doubled.")
 (defconst tramp-hlo-list-parents-script "\
 TEST=\"${1%%/}\"
 [ -z \"$TEST\" ] && echo \"()\" && return
-if [ ! -d $(%r -f \"$TEST\") ]; then
+if [ ! -d \"$(%r -f \"$TEST\")\" ]; then
     TEST=\"$(dirname \"$TEST\")\"
 fi
 echo \\(
 while
-    if [ -d \"$TEST\" ]; then
-        %k \"$TEST\" | sed \"s|^$HOME|~|\"
-    fi
+    %k \"$TEST\" | sed \"s|^$HOME|~|\"
     [ \"$TEST\" != \"/\" ]
 do TEST=$(dirname \"$TEST\"); done
 echo \\)
@@ -82,7 +80,7 @@ characters need to be doubled.")
 (defconst tramp-hlo-locate-dominating-file-multi-script "\
 TEST=\"${1%%/}\"
 [ -z \"$TEST\" ] && echo \"()\" && return
-if [ ! -d $(%r -f \"$TEST\") ]; then
+if [ ! -d \"$(%r -f \"$TEST\")\" ]; then
     TEST=\"$(dirname \"$TEST\")\"
 fi
 shift


### PR DESCRIPTION
This may need some conversation, especially about test cases I haven't thought of or tried.

Fix for https://github.com/jsadusk/tramp-hlo/issues/6

The issue:
When in the actual directory in question, both the "parents" script and the "dominating file" script do not consider the current directory that is fed to them.  This is counter to the built-ins behavior.

However, my changes are not quite equivalent. There were tests against the TEST variable being empty, but I don't know how that could happen.  So perhaps that's things I haven't thought about.

Also, I'm not sure if the issues here also apply to other scripts?

It's hard to know how to document the script itself.  I could add a code comment beside it maybe.  I'll explain in PR comments here to help you review.